### PR TITLE
Logger interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Instana Go sensor consists of two parts:
 To use sensor only without tracing ability, import the `instana` package and run
 
 	instana.InitSensor(opt)
-	
+
 in your main function. The init function takes an `Options` object with the following optional fields:
 
 * **Service** - global service name that will be used to identify the program in the Instana backend
@@ -19,10 +19,10 @@ Once initialised, the sensor will try to connect to the given Instana agent and 
 
 In case you want to use the OpenTracing tracer, it will automatically initialise the sensor and thus also activate the metrics stream. To activate the global tracer, run for example
 
-	ot.InitGlobalTracer(instana.NewTracerWithOptions(&instana.Options{
-		Service:  SERVICE,
-		LogLevel: instana.DEBUG}))
-		
+	ot.InitGlobalTracer(instana.NewTracerWithOptions(
+	    &instana.Options{ Service:  SERVICE }
+	))
+
 in your main functions. The tracer takes same options that the sensor takes for initialisation, described above.
 
 The tracer is able to protocol and piggyback OpenTracing baggage, tags and logs. Only text mapping is implemented yet, binary is not supported. Also, the tracer tries to map the OpenTracing spans to the Instana model according to the following strategy:
@@ -39,3 +39,5 @@ Following examples are included in the `examples` folder:
 * **simple** - demoes generally how to use the tracer
 * **http** - demoes how http server and client should be instrumented
 * **rpc** - demoes the fallback to RPC
+
+In case you'd like to debug or you need to troubleshoot, you can set `instana.Logger` and capture the output.

--- a/agent.go
+++ b/agent.go
@@ -116,14 +116,14 @@ func (r *agentS) fullRequestResponse(url string, method string, data interface{}
 			if err == nil {
 				if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 					err = errors.New(resp.Status)
-					log.error(err)
+					Logger.Println(err)
 					if r.canSend() {
 						r.reset()
 					}
 				} else {
 					defer resp.Body.Close()
 
-					log.debug("agent response:", url, resp.Status)
+					Logger.Printf("agent response with status:%s from url: %s", resp.Status, url)
 
 					if body != nil {
 						var b []byte
@@ -136,21 +136,21 @@ func (r *agentS) fullRequestResponse(url string, method string, data interface{}
 					}
 				}
 			} else {
-				log.error(err)
+				Logger.Println(err)
 
 				if resp == nil {
 					r.reset()
 				}
 			}
 		} else {
-			log.error(err)
+			Logger.Println(err)
 
 			if resp == nil {
 				r.reset()
 			}
 		}
 	} else {
-		log.error(err)
+		Logger.Println(err)
 	}
 
 	return ret, err
@@ -171,7 +171,7 @@ func (r *agentS) setHost(host string) {
 
 func (r *sensorS) initAgent() *agentS {
 
-	log.debug("initializing agent")
+	Logger.Println("initializing agent")
 
 	ret := new(agentS)
 	ret.sensor = r

--- a/example/rpc.go
+++ b/example/rpc.go
@@ -27,8 +27,8 @@ func rpc(ctx context.Context) {
 
 func main() {
 	ot.InitGlobalTracer(instana.NewTracerWithOptions(&instana.Options{
-		Service:  Service,
-		LogLevel: instana.Debug}))
+		Service: Service,
+	}))
 
 	go forever()
 	select {}

--- a/example/simple.go
+++ b/example/simple.go
@@ -46,8 +46,8 @@ func simple(ctx context.Context) {
 
 func main() {
 	ot.InitGlobalTracer(instana.NewTracerWithOptions(&instana.Options{
-		Service:  Service,
-		LogLevel: instana.Debug}))
+		Service: Service,
+	}))
 
 	go forever()
 	select {}

--- a/log.go
+++ b/log.go
@@ -1,51 +1,18 @@
 package instana
 
 import (
-	l "log"
+	"io/ioutil"
+	"log"
 )
 
-const (
-	Error = 0
-	Warn  = 1
-	Info  = 2
-	Debug = 3
-)
+// Logger is an instance of the StdLogger interface, used by the sensor to log relevant events.
+// By default it is set to discard all log messages via ioutil.Discard.
+// Since it is an exported global variable, it can be set to redirect to any desired output.
+var Logger StdLogger = log.New(ioutil.Discard, "[instana]", log.LstdFlags)
 
-type logS struct {
-	sensor *sensorS
-}
-
-var log *logS
-
-func (r *logS) makeV(prefix string, v ...interface{}) []interface{} {
-	return append([]interface{}{prefix}, v...)
-}
-
-func (r *logS) debug(v ...interface{}) {
-	if r.sensor.options.LogLevel >= Debug {
-		l.Println(r.makeV("DEBUG: instana:", v...)...)
-	}
-}
-
-func (r *logS) info(v ...interface{}) {
-	if r.sensor.options.LogLevel >= Info {
-		l.Println(r.makeV("INFO: instana:", v...)...)
-	}
-}
-
-func (r *logS) warn(v ...interface{}) {
-	if r.sensor.options.LogLevel >= Warn {
-		l.Println(r.makeV("WARN: instana:", v...)...)
-	}
-}
-
-func (r *logS) error(v ...interface{}) {
-	if r.sensor.options.LogLevel >= Error {
-		l.Println(r.makeV("ERROR: instana:", v...)...)
-	}
-}
-
-func (r *sensorS) initLog() {
-	log = new(logS)
-	log.sensor = r
+// StdLogger declares methods for logging messages
+type StdLogger interface {
+	Print(v ...interface{})
+	Printf(format string, v ...interface{})
+	Println(v ...interface{})
 }

--- a/meter.go
+++ b/meter.go
@@ -67,7 +67,7 @@ func (r *meterS) init() {
 				if r.snapshotCountdown == 0 {
 					r.snapshotCountdown = SnapshotPeriod
 					s = r.collectSnapshot()
-					log.debug("collected snapshot")
+					Logger.Println("collected snapshot")
 				} else {
 					s = nil
 				}
@@ -132,7 +132,7 @@ func (r *meterS) collectSnapshot() *SnapshotS {
 
 func (r *sensorS) initMeter() *meterS {
 
-	log.debug("initializing meter")
+	Logger.Println("initializing meter")
 
 	ret := new(meterS)
 	ret.sensor = r

--- a/sensor.go
+++ b/sensor.go
@@ -47,8 +47,7 @@ func (r *sensorS) configureServiceName() {
 
 func InitSensor(options *Options) {
 	sensor = new(sensorS)
-	sensor.initLog()
 	sensor.init(options)
 
-	log.debug("initialized sensor")
+	Logger.Println("initialized sensor")
 }


### PR DESCRIPTION
Hi, since I saw you're open to PRs, I'd like to propose this refactoring of the logger from a very specific implementation into a global exported variable implementing a minimalistic interface. The reasons for the proposed change include the following:

1. This being a library to be integrated in applications, would leave the choice to the developers of the application using the sensor, whether to enable the sensor logging (by setting instana.Logger) or not (the default logger in the PR discards all messages) and on which log level to do so.
2. I'd argue the point that most applications use structured loggers, so they could set the logger variable to their logger or write a small adapter that implements the three methods declared in StdLogger.
3. Not everyone logs messages to StdOut as the default logger does.