### PR TITLE
Closer to OT recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Instana Go sensor consists of two parts:
 To use sensor only without tracing ability, import the `instana` package and run
 
 	instana.InitSensor(opt)
-	
+
 in your main function. The init function takes an `Options` object with the following optional fields:
 
 * **Service** - global service name that will be used to identify the program in the Instana backend
@@ -22,15 +22,10 @@ In case you want to use the OpenTracing tracer, it will automatically initialise
 	ot.InitGlobalTracer(instana.NewTracerWithOptions(&instana.Options{
 		Service:  SERVICE,
 		LogLevel: instana.DEBUG}))
-		
+
 in your main functions. The tracer takes same options that the sensor takes for initialisation, described above.
 
-The tracer is able to protocol and piggyback OpenTracing baggage, tags and logs. Only text mapping is implemented yet, binary is not supported. Also, the tracer tries to map the OpenTracing spans to the Instana model according to the following strategy:
-
-* in order to use the fully qualified Instana exit/entry/error tracing, two Logs need to be provided:
-	* **type** - can be either HTTP_SERVER, HTTP_CLIENT or RPC
-	* **data** - corresponding data structure, either `HttpData` or `RpcData`
-* in case the type is not provided, the created span defaults to `RPC` and data is automatically collected the best effort way
+The tracer is able to protocol and piggyback OpenTracing baggage, tags and logs. Only text mapping is implemented yet, binary is not supported. Also, the tracer tries to map the OpenTracing spans to the Instana model based on OpenTracing recommended tags. See `simple` example for details on how recommended tags are used.
 
 The Instana tracer will remap OpenTracing HTTP headers into Instana Headers, so parallel use with some other OpenTracing model is not possible. The instana tracer is based on the OpenTracing Go basictracer with necessary modifications to map to the Instana tracing model. Also, sampling isn't implemented yet and will be focus of future work.
 

--- a/example/simple.go
+++ b/example/simple.go
@@ -25,6 +25,7 @@ func simple(ctx context.Context) {
 				Method: "GET"}}))
 
 	childSpan := ot.StartSpan("child", ot.ChildOf(parentSpan.Context()))
+	childSpan.SetTag("component", "bar")
 	childSpan.LogFields(
 		log.String("type", instana.HTTP_CLIENT),
 		log.Object("data", &instana.Data{

--- a/example/simple.go
+++ b/example/simple.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/instana/golang-sensor"
 	ot "github.com/opentracing/opentracing-go"
+	ext "github.com/opentracing/opentracing-go/ext"
 	"github.com/opentracing/opentracing-go/log"
 	"golang.org/x/net/context"
 )
@@ -25,15 +26,11 @@ func simple(ctx context.Context) {
 				Method: "GET"}}))
 
 	childSpan := ot.StartSpan("child", ot.ChildOf(parentSpan.Context()))
-	childSpan.SetTag("component", "bar")
-	childSpan.LogFields(
-		log.String("type", instana.HTTP_CLIENT),
-		log.Object("data", &instana.Data{
-			Http: &instana.HttpData{
-				Host:   "localhost",
-				Url:    "/golang/simple/two",
-				Status: 204,
-				Method: "POST"}}))
+	childSpan.SetTag(string(ext.Component), "bar")
+	childSpan.SetTag(string(ext.PeerHostname), "localhost")
+	childSpan.SetTag(string(ext.HTTPUrl), "/golang/simple/two")
+	childSpan.SetTag(string(ext.HTTPMethod), "POST")
+	childSpan.SetTag(string(ext.HTTPStatusCode), 204)
 	childSpan.SetBaggageItem("someBaggage", "someValue")
 
 	time.Sleep(450 * time.Millisecond)

--- a/example/simple.go
+++ b/example/simple.go
@@ -6,7 +6,6 @@ import (
 	"github.com/instana/golang-sensor"
 	ot "github.com/opentracing/opentracing-go"
 	ext "github.com/opentracing/opentracing-go/ext"
-	"github.com/opentracing/opentracing-go/log"
 	"golang.org/x/net/context"
 )
 
@@ -16,17 +15,15 @@ const (
 
 func simple(ctx context.Context) {
 	parentSpan, ctx := ot.StartSpanFromContext(ctx, "parent")
-	parentSpan.LogFields(
-		log.String("type", instana.HTTP_SERVER),
-		log.Object("data", &instana.Data{
-			Http: &instana.HttpData{
-				Host:   "localhost",
-				Url:    "/golang/simple/one",
-				Status: 200,
-				Method: "GET"}}))
+	parentSpan.SetTag(string(ext.Component), SERVICE)
+	parentSpan.SetTag(string(ext.SpanKind), string(ext.SpanKindRPCServerEnum))
+	parentSpan.SetTag(string(ext.PeerHostname), "localhost")
+	parentSpan.SetTag(string(ext.HTTPUrl), "/golang/simple/one")
+	parentSpan.SetTag(string(ext.HTTPMethod), "GET")
+	parentSpan.SetTag(string(ext.HTTPStatusCode), 200)
 
 	childSpan := ot.StartSpan("child", ot.ChildOf(parentSpan.Context()))
-	childSpan.SetTag(string(ext.Component), "bar")
+	childSpan.SetTag(string(ext.SpanKind), string(ext.SpanKindRPCClientEnum))
 	childSpan.SetTag(string(ext.PeerHostname), "localhost")
 	childSpan.SetTag(string(ext.HTTPUrl), "/golang/simple/two")
 	childSpan.SetTag(string(ext.HTTPMethod), "POST")

--- a/recorder.go
+++ b/recorder.go
@@ -83,6 +83,15 @@ func getHostName(rawSpan basictracer.RawSpan) string {
 	return h
 }
 
+func getHttpType(rawSpan basictracer.RawSpan) string {
+	kind := getStringTag(rawSpan, string(ext.SpanKind))
+	if kind == string(ext.SpanKindRPCServerEnum) {
+		return HTTP_SERVER
+	}
+
+	return HTTP_CLIENT
+}
+
 func (r *InstanaSpanRecorder) RecordSpan(rawSpan basictracer.RawSpan) {
 	data := getDataLogField(rawSpan)
 	tp := getStringSpanLogField(rawSpan, "type")
@@ -90,14 +99,12 @@ func (r *InstanaSpanRecorder) RecordSpan(rawSpan basictracer.RawSpan) {
 		h := getHostName(rawSpan)
 		status := getTag(rawSpan, string(ext.HTTPStatusCode))
 		if status != nil {
-			tp = HTTP_CLIENT
+			tp = getHttpType(rawSpan)
 			data = &Data{Http: &HttpData{
 				Host:   h,
 				Url:    getStringTag(rawSpan, string(ext.HTTPUrl)),
 				Method: getStringTag(rawSpan, string(ext.HTTPMethod)),
 				Status: status.(int)}}
-
-			log.debug(data.Http)
 		} else {
 			tp = RPC
 			data = &Data{Rpc: &RpcData{

--- a/recorder.go
+++ b/recorder.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/opentracing/basictracer-go"
+	ext "github.com/opentracing/opentracing-go/ext"
 )
 
 type InstanaSpanRecorder struct {
@@ -55,6 +56,19 @@ func getDataLogField(rawSpan basictracer.RawSpan) *Data {
 	return nil
 }
 
+func getTag(rawSpan basictracer.RawSpan, tag string) interface{} {
+	return rawSpan.Tags[tag]
+}
+
+func getStringTag(rawSpan basictracer.RawSpan, tag string) string {
+	d := getTag(rawSpan, tag)
+	if d == nil {
+		return ""
+	}
+
+	return d.(string)
+}
+
 func (r *InstanaSpanRecorder) RecordSpan(rawSpan basictracer.RawSpan) {
 	data := getDataLogField(rawSpan)
 	tp := getStringSpanLogField(rawSpan, "type")
@@ -81,6 +95,7 @@ func (r *InstanaSpanRecorder) RecordSpan(rawSpan basictracer.RawSpan) {
 		data.Baggage = baggage
 	}
 
+	data.Service = getStringTag(rawSpan, string(ext.Component))
 	if data.Service == "" {
 		data.Service = sensor.serviceName
 	}

--- a/recorder.go
+++ b/recorder.go
@@ -83,6 +83,18 @@ func getHostName(rawSpan basictracer.RawSpan) string {
 	return h
 }
 
+func getServiceName(rawSpan basictracer.RawSpan) string {
+	s := getStringTag(rawSpan, string(ext.Component))
+	if s == "" {
+		s := getStringTag(rawSpan, string(ext.PeerService))
+		if s == "" {
+			s = sensor.serviceName
+		}
+	}
+
+	return s
+}
+
 func getHttpType(rawSpan basictracer.RawSpan) string {
 	kind := getStringTag(rawSpan, string(ext.SpanKind))
 	if kind == string(ext.SpanKindRPCServerEnum) {
@@ -125,10 +137,7 @@ func (r *InstanaSpanRecorder) RecordSpan(rawSpan basictracer.RawSpan) {
 		data.Baggage = baggage
 	}
 
-	data.Service = getStringTag(rawSpan, string(ext.Component))
-	if data.Service == "" {
-		data.Service = sensor.serviceName
-	}
+	data.Service = getServiceName(rawSpan)
 
 	var parentId *uint64
 	if rawSpan.ParentSpanID == 0 {

--- a/recorder.go
+++ b/recorder.go
@@ -93,6 +93,7 @@ func getHttpType(rawSpan basictracer.RawSpan) string {
 }
 
 func (r *InstanaSpanRecorder) RecordSpan(rawSpan basictracer.RawSpan) {
+	//TODO: remove log field misuse after merge
 	data := getDataLogField(rawSpan)
 	tp := getStringSpanLogField(rawSpan, "type")
 	if data == nil {

--- a/recorder.go
+++ b/recorder.go
@@ -86,16 +86,16 @@ func getHostName(rawSpan basictracer.RawSpan) string {
 func getServiceName(rawSpan basictracer.RawSpan) string {
 	s := getStringTag(rawSpan, string(ext.Component))
 	if s == "" {
-		s := getStringTag(rawSpan, string(ext.PeerService))
+		s = getStringTag(rawSpan, string(ext.PeerService))
 		if s == "" {
-			s = sensor.serviceName
+			return sensor.serviceName
 		}
 	}
 
 	return s
 }
 
-func getHttpType(rawSpan basictracer.RawSpan) string {
+func getHTTPType(rawSpan basictracer.RawSpan) string {
 	kind := getStringTag(rawSpan, string(ext.SpanKind))
 	if kind == string(ext.SpanKindRPCServerEnum) {
 		return HTTP_SERVER
@@ -112,7 +112,7 @@ func (r *InstanaSpanRecorder) RecordSpan(rawSpan basictracer.RawSpan) {
 		h := getHostName(rawSpan)
 		status := getTag(rawSpan, string(ext.HTTPStatusCode))
 		if status != nil {
-			tp = getHttpType(rawSpan)
+			tp = getHTTPType(rawSpan)
 			data = &Data{Http: &HttpData{
 				Host:   h,
 				Url:    getStringTag(rawSpan, string(ext.HTTPUrl)),


### PR DESCRIPTION
The initial implementation is misusing log fields to piggyback type and data structure needed to translate from OT into our model. With this PR it is not necessary anymore, since OT recommends tags that map well to our mainly HTTP spans.

Since RPC has been used as default fallback, there is no need to adjust any client code yet. In case of HTTP client and server spans, it is necessary to remove misused logs as these are not supported anymore, and instead use tags as can be seen in the simple and http examples.

In the next step, RPC will become explicit, and a fallback to our more sophisticated, but generic SDK span type will be used instead. So in case explicit RPC spans have been used, client code should use the fallback instead now to prepare for the near future SDK fallback.