### PR TITLE
reworked to be more robust against communication issues and cornercases

### DIFF
--- a/example/simple.go
+++ b/example/simple.go
@@ -48,6 +48,7 @@ func main() {
 		LogLevel: instana.Debug}))
 
 	go forever()
+	go forever()
 	select {}
 }
 

--- a/fsm.go
+++ b/fsm.go
@@ -15,13 +15,15 @@ const (
 	EAnnounce = "announce"
 	ETest     = "test"
 
-	RetryPeriod = 30 * 1000
+	RetryPeriod    = 30 * 1000
+	MaximumRetries = 2
 )
 
 type fsmS struct {
-	agent *agentS
-	fsm   *f.FSM
-	timer *time.Timer
+	agent   *agentS
+	fsm     *f.FSM
+	timer   *time.Timer
+	retries int
 }
 
 func (r *fsmS) init() {
@@ -39,6 +41,9 @@ func (r *fsmS) init() {
 			"init":              r.lookupAgentHost,
 			"enter_unannounced": r.announceSensor,
 			"enter_announced":   r.testAgent})
+
+	r.retries = MaximumRetries
+	r.fsm.Event(EInit)
 }
 
 func (r *fsmS) scheduleRetry(e *f.Event, cb func(e *f.Event)) {
@@ -98,6 +103,7 @@ func (r *fsmS) lookupSuccess(host string) {
 	log.debug("agent lookup success", host)
 
 	r.agent.setHost(host)
+	r.retries = MaximumRetries
 	r.fsm.Event(ELookup)
 }
 
@@ -105,10 +111,16 @@ func (r *fsmS) announceSensor(e *f.Event) {
 	cb := func(b bool, from *FromS) {
 		if b {
 			r.agent.setFrom(from)
+			r.retries = MaximumRetries
 			r.fsm.Event(EAnnounce)
 		} else {
 			log.error("Cannot announce sensor. Scheduling retry.")
-			r.scheduleRetry(e, r.announceSensor)
+			r.retries--
+			if r.retries > 0 {
+				r.scheduleRetry(e, r.announceSensor)
+			} else {
+				r.fsm.Event(EInit)
+			}
 		}
 	}
 
@@ -132,10 +144,16 @@ func (r *fsmS) announceSensor(e *f.Event) {
 func (r *fsmS) testAgent(e *f.Event) {
 	cb := func(b bool) {
 		if b {
+			r.retries = MaximumRetries
 			r.fsm.Event(ETest)
 		} else {
 			log.error("Agent is not yet ready. Scheduling retry.")
-			r.scheduleRetry(e, r.testAgent)
+			r.retries--
+			if r.retries > 0 {
+				r.scheduleRetry(e, r.testAgent)
+			} else {
+				r.fsm.Event(EInit)
+			}
 		}
 	}
 
@@ -148,6 +166,7 @@ func (r *fsmS) testAgent(e *f.Event) {
 }
 
 func (r *fsmS) reset() {
+	r.retries = MaximumRetries
 	r.fsm.Event(EInit)
 }
 

--- a/meter.go
+++ b/meter.go
@@ -78,10 +78,18 @@ func (r *meterS) init() {
 					Snapshot: s,
 					Metrics:  r.collectMetrics()}
 
-				go r.sensor.agent.request(r.sensor.agent.makeURL(AgentDataURL), "POST", d)
+				go r.send(d)
 			}
 		}
 	}()
+}
+
+func (r *meterS) send(d *EntityData) {
+	_, err := r.sensor.agent.request(r.sensor.agent.makeURL(AgentDataURL), "POST", d)
+
+	if err != nil {
+		r.sensor.agent.reset()
+	}
 }
 
 func (r *meterS) collectMemoryMetrics() *MemoryS {

--- a/recorder.go
+++ b/recorder.go
@@ -142,6 +142,14 @@ func (r *SpanRecorder) RecordSpan(rawSpan basictracer.RawSpan) {
 			From:      sensor.agent.from,
 			Data:      &data}
 
-		go sensor.agent.request(sensor.agent.makeURL(AgentTracesURL), "POST", []interface{}{span})
+		go r.send(sensor, span)
+	}
+}
+
+func (r *SpanRecorder) send(sensor *sensorS, span *Span) {
+	_, err := sensor.agent.request(sensor.agent.makeURL(AgentTracesURL), "POST", []interface{}{span})
+
+	if err != nil {
+		sensor.agent.reset()
 	}
 }


### PR DESCRIPTION
Current implementation partially has state machine logic outside of FSM, with agent state to be reset basically on every HTTP error. This turned out to be brittle in various scenarios where agent cannot be reached anymore or discovery fails and alike. This branch reworks the sensor to be more robust against different cornercases by keeping and managing the state fully inside the state machine, introducing maximum retries in different states with fallback to the initial state, plus some small bug fixes.