### PR TITLE
Type safe HTTP status

### DIFF
--- a/example/simple.go
+++ b/example/simple.go
@@ -21,7 +21,7 @@ func simple(ctx context.Context) {
 	parentSpan.SetTag(string(ext.PeerHostname), "localhost")
 	parentSpan.SetTag(string(ext.HTTPUrl), "/golang/simple/one")
 	parentSpan.SetTag(string(ext.HTTPMethod), "GET")
-	parentSpan.SetTag(string(ext.HTTPStatusCode), 200)
+	parentSpan.SetTag(string(ext.HTTPStatusCode), uint16(200))
 	parentSpan.LogFields(
 		log.String("foo", "bar"))
 


### PR DESCRIPTION
In the standard Go http library, HTTP status code is an int, while OT seems to want to use uint16 instead. For those who pass uint16 we ended up panicking on type conversion. This PR solves this by only accepting int HTTP status code for HTTP spans, while opting out safely to RPC on uint16 (and any other type).