### PR TITLE
OT spans should be reported using the sdk span type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+debug.test

--- a/custom.go
+++ b/custom.go
@@ -5,6 +5,7 @@ import (
 )
 
 type CustomData struct {
-	Tags ot.Tags                           `json:"tags,omitempty"`
-	Logs map[uint64]map[string]interface{} `json:"logs,omitempty"`
+	Tags    ot.Tags                           `json:"tags,omitempty"`
+	Logs    map[uint64]map[string]interface{} `json:"logs,omitempty"`
+	Baggage map[string]string                 `json:"baggage,omitempty"`
 }

--- a/data.go
+++ b/data.go
@@ -2,6 +2,7 @@ package instana
 
 type Data struct {
 	Service string            `json:"service"`
+	SDK     *SDKData          `json:"sdk,omitempty"`
 	HTTP    *HTTPData         `json:"http,omitempty"`
 	RPC     *RPCData          `json:"rpc,omitempty"`
 	Baggage map[string]string `json:"baggage,omitempty"`

--- a/data.go
+++ b/data.go
@@ -1,10 +1,6 @@
 package instana
 
 type Data struct {
-	Service string            `json:"service"`
-	SDK     *SDKData          `json:"sdk,omitempty"`
-	HTTP    *HTTPData         `json:"http,omitempty"`
-	RPC     *RPCData          `json:"rpc,omitempty"`
-	Baggage map[string]string `json:"baggage,omitempty"`
-	Custom  *CustomData       `json:"custom,omitempty"`
+	Service string   `json:"service"`
+	SDK     *SDKData `json:"sdk,omitempty"`
 }

--- a/data.go
+++ b/data.go
@@ -1,6 +1,6 @@
 package instana
 
 type Data struct {
-	Service string   `json:"service"`
-	SDK     *SDKData `json:"sdk,omitempty"`
+	Service string   `json:"service,omitempty"`
+	SDK     *SDKData `json:"sdk"`
 }

--- a/options.go
+++ b/options.go
@@ -7,4 +7,5 @@ type Options struct {
 	MaxBufferedSpans            int
 	ForceTransmissionStartingAt int
 	LogLevel                    int
+	TestMode                    bool
 }

--- a/options.go
+++ b/options.go
@@ -7,5 +7,4 @@ type Options struct {
 	MaxBufferedSpans            int
 	ForceTransmissionStartingAt int
 	LogLevel                    int
-	TestMode                    bool
 }

--- a/recorder.go
+++ b/recorder.go
@@ -27,11 +27,17 @@ type Span struct {
 }
 
 // NewRecorder Establish a new span recorder
-func NewRecorder(testMode bool) *SpanRecorder {
+func NewRecorder() *SpanRecorder {
 	r := new(SpanRecorder)
-	r.testMode = testMode
 	r.init()
+	return r
+}
 
+// NewTestRecorder Establish a new span recorder used for testing
+func NewTestRecorder() *SpanRecorder {
+	r := new(SpanRecorder)
+	r.testMode = true
+	r.init()
 	return r
 }
 

--- a/recorder.go
+++ b/recorder.go
@@ -106,13 +106,14 @@ func getServiceName(rawSpan basictracer.RawSpan) string {
 
 func getSpanKind(rawSpan basictracer.RawSpan) string {
 	kind := getStringTag(rawSpan, string(ext.SpanKind))
-	if kind == string(ext.SpanKindRPCServerEnum) || kind == "consumer" {
+
+	switch kind {
+	case string(ext.SpanKindRPCServerEnum), "consumer", "entry":
 		return "entry"
-	} else if kind == string(ext.SpanKindRPCClientEnum) || kind == "producer" {
+	case string(ext.SpanKindRPCClientEnum), "producer", "exit":
 		return "exit"
-	} else {
-		return ""
 	}
+	return ""
 }
 
 func collectLogs(rawSpan basictracer.RawSpan) map[uint64]map[string]interface{} {

--- a/recorder.go
+++ b/recorder.go
@@ -138,18 +138,19 @@ func (r *SpanRecorder) RecordSpan(rawSpan basictracer.RawSpan) {
 			Host:   h,
 			URL:    getStringTag(rawSpan, string(ext.HTTPUrl)),
 			Method: getStringTag(rawSpan, string(ext.HTTPMethod)),
-			Status: status}}
+			Status: status},
+			SDK: &SDKData{Name: tp}}
 	} else {
 		log.debug("No HTTP status code provided or invalid status code, opting out to RPC")
 
 		tp = RPC
 		data = &Data{RPC: &RPCData{
 			Host: h,
-			Call: rawSpan.Operation}}
+			Call: rawSpan.Operation},
+			SDK: &SDKData{Name: tp}}
 	}
 
-	data.Custom = &CustomData{Tags: rawSpan.Tags,
-		Logs: collectLogs(rawSpan)}
+	data.Custom = &CustomData{Tags: rawSpan.Tags, Logs: collectLogs(rawSpan)}
 
 	baggage := make(map[string]string)
 	rawSpan.Context.ForeachBaggageItem(func(k string, v string) bool {
@@ -184,7 +185,7 @@ func (r *SpanRecorder) RecordSpan(rawSpan basictracer.RawSpan) {
 		SpanID:    rawSpan.Context.SpanID,
 		Timestamp: uint64(rawSpan.Start.UnixNano()) / uint64(time.Millisecond),
 		Duration:  uint64(rawSpan.Duration) / uint64(time.Millisecond),
-		Name:      tp,
+		Name:      "sdk",
 		From:      sensor.agent.from,
 		Data:      &data})
 

--- a/recorder.go
+++ b/recorder.go
@@ -94,9 +94,9 @@ func getHostName(rawSpan basictracer.RawSpan) string {
 func getServiceName(rawSpan basictracer.RawSpan) string {
 	// ServiceName can be determined from multiple sources and has
 	// the following priority (preferred first):
-	//   1. Added to the span via the OT component tag
-	//   2. If span has http.url, then return ""
-	//   2. Specified in the tracer instantiation
+	//   1. If added to the span via the OT component tag
+	//   2. If added to the span via the OT http.url tag
+	//   3. Specified in the tracer instantiation via Service option
 	component := getStringTag(rawSpan, string(ext.Component))
 
 	if len(component) == 0 {

--- a/recorder.go
+++ b/recorder.go
@@ -99,13 +99,14 @@ func getServiceName(rawSpan basictracer.RawSpan) string {
 	//   3. Specified in the tracer instantiation via Service option
 	component := getStringTag(rawSpan, string(ext.Component))
 
-	if len(component) == 0 {
+	if len(component) > 0 {
+		return component
+	} else if len(component) == 0 {
 		httpURL := getStringTag(rawSpan, string(ext.HTTPUrl))
 
 		if len(httpURL) > 0 {
 			return httpURL
 		}
-		return component
 	}
 	return sensor.serviceName
 }

--- a/recorder.go
+++ b/recorder.go
@@ -1,6 +1,7 @@
 package instana
 
 import (
+	"fmt"
 	"os"
 	"sync"
 	"time"
@@ -51,7 +52,11 @@ func (r *SpanRecorder) GetSpans() []Span {
 }
 
 func getTag(rawSpan basictracer.RawSpan, tag string) interface{} {
-	return rawSpan.Tags[tag]
+	var x, ok = rawSpan.Tags[tag]
+	if !ok {
+		x = ""
+	}
+	return x
 }
 
 func getIntTag(rawSpan basictracer.RawSpan, tag string) int {
@@ -69,12 +74,11 @@ func getIntTag(rawSpan basictracer.RawSpan, tag string) int {
 }
 
 func getStringTag(rawSpan basictracer.RawSpan, tag string) string {
-	d := getTag(rawSpan, tag)
+	d := rawSpan.Tags[tag]
 	if d == nil {
 		return ""
 	}
-
-	return d.(string)
+	return fmt.Sprint(d)
 }
 
 func getHostName(rawSpan basictracer.RawSpan) string {

--- a/recorder_internal_test.go
+++ b/recorder_internal_test.go
@@ -8,12 +8,10 @@ import (
 )
 
 func TestGetServiceName(t *testing.T) {
-	opts := Options{
-		TestMode: true,
-		LogLevel: Debug}
+	opts := Options{LogLevel: Debug}
 
 	InitSensor(&opts)
-	recorder := NewRecorder(opts.TestMode)
+	recorder := NewTestRecorder()
 	tracer := NewTracerWithEverything(&opts, recorder)
 
 	sp := tracer.StartSpan("http-client")
@@ -30,12 +28,10 @@ func TestGetServiceName(t *testing.T) {
 }
 
 func TestSpanKind(t *testing.T) {
-	opts := Options{
-		TestMode: true,
-		LogLevel: Debug}
+	opts := Options{LogLevel: Debug}
 
 	InitSensor(&opts)
-	recorder := NewRecorder(opts.TestMode)
+	recorder := NewTestRecorder()
 	tracer := NewTracerWithEverything(&opts, recorder)
 
 	sp := tracer.StartSpan("http-client")

--- a/recorder_internal_test.go
+++ b/recorder_internal_test.go
@@ -1,0 +1,37 @@
+package instana
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	ext "github.com/opentracing/opentracing-go/ext"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetServiceName(t *testing.T) {
+	opts := Options{
+		TestMode: true,
+		LogLevel: Debug}
+
+	InitSensor(&opts)
+	recorder := NewRecorder(opts.TestMode)
+	tracer := NewTracerWithEverything(&opts, recorder)
+
+	sp := tracer.StartSpan("http-client")
+	sp.SetTag(string(ext.SpanKind), "exit")
+	sp.SetTag("http.status", 200)
+	sp.SetTag("http.url", "https://www.instana.com/product/")
+	sp.SetTag(string(ext.HTTPMethod), "GET")
+
+	sp.Finish()
+
+	rawSpan := sp.(*spanS).raw
+	serviceName := getServiceName(rawSpan)
+	assert.EqualValues(t, "https://www.instana.com/product/", serviceName, "Wrong Service Name")
+
+	spans := recorder.GetSpans()
+	j, _ := json.MarshalIndent(spans, "", "  ")
+	fmt.Printf("%s", bytes.NewBuffer(j))
+}

--- a/recorder_internal_test.go
+++ b/recorder_internal_test.go
@@ -1,9 +1,6 @@
 package instana
 
 import (
-	"bytes"
-	"encoding/json"
-	"fmt"
 	"testing"
 
 	ext "github.com/opentracing/opentracing-go/ext"
@@ -30,8 +27,26 @@ func TestGetServiceName(t *testing.T) {
 	rawSpan := sp.(*spanS).raw
 	serviceName := getServiceName(rawSpan)
 	assert.EqualValues(t, "https://www.instana.com/product/", serviceName, "Wrong Service Name")
+}
 
-	spans := recorder.GetSpans()
-	j, _ := json.MarshalIndent(spans, "", "  ")
-	fmt.Printf("%s", bytes.NewBuffer(j))
+func TestSpanKind(t *testing.T) {
+	opts := Options{
+		TestMode: true,
+		LogLevel: Debug}
+
+	InitSensor(&opts)
+	recorder := NewRecorder(opts.TestMode)
+	tracer := NewTracerWithEverything(&opts, recorder)
+
+	sp := tracer.StartSpan("http-client")
+	sp.SetTag(string(ext.SpanKind), "exit")
+	sp.SetTag("http.status", 200)
+	sp.SetTag("http.url", "https://www.instana.com/product/")
+	sp.SetTag(string(ext.HTTPMethod), "GET")
+
+	sp.Finish()
+
+	rawSpan := sp.(*spanS).raw
+	kind := getSpanKind(rawSpan)
+	assert.EqualValues(t, "exit", kind, "Wrong span kind")
 }

--- a/recorder_internal_test.go
+++ b/recorder_internal_test.go
@@ -73,15 +73,110 @@ func TestSpanKind(t *testing.T) {
 	recorder := NewTestRecorder()
 	tracer := NewTracerWithEverything(&opts, recorder)
 
+	// Exit
 	sp := tracer.StartSpan("http-client")
 	sp.SetTag(string(ext.SpanKind), "exit")
-	sp.SetTag("http.status", 200)
-	sp.SetTag("http.url", "https://www.instana.com/product/")
-	sp.SetTag(string(ext.HTTPMethod), "GET")
-
 	sp.Finish()
-
 	rawSpan := sp.(*spanS).raw
 	kind := getSpanKind(rawSpan)
 	assert.EqualValues(t, "exit", kind, "Wrong span kind")
+
+	// Entry
+	sp = tracer.StartSpan("http-client")
+	sp.SetTag(string(ext.SpanKind), "entry")
+	sp.Finish()
+	rawSpan = sp.(*spanS).raw
+	kind = getSpanKind(rawSpan)
+	assert.EqualValues(t, "entry", kind, "Wrong span kind")
+
+	// Consumer
+	sp = tracer.StartSpan("http-client")
+	sp.SetTag(string(ext.SpanKind), "consumer")
+	sp.Finish()
+	rawSpan = sp.(*spanS).raw
+	kind = getSpanKind(rawSpan)
+	assert.EqualValues(t, "entry", kind, "Wrong span kind")
+
+	// Producer
+	sp = tracer.StartSpan("http-client")
+	sp.SetTag(string(ext.SpanKind), "producer")
+	sp.Finish()
+	rawSpan = sp.(*spanS).raw
+	kind = getSpanKind(rawSpan)
+	assert.EqualValues(t, "exit", kind, "Wrong span kind")
+}
+
+func TestGetTag(t *testing.T) {
+	opts := Options{LogLevel: Debug}
+
+	InitSensor(&opts)
+	recorder := NewTestRecorder()
+	tracer := NewTracerWithEverything(&opts, recorder)
+
+	// Exit
+	sp := tracer.StartSpan("http-client")
+	sp.SetTag("foo", "bar")
+	sp.Finish()
+	rawSpan := sp.(*spanS).raw
+	tag := getTag(rawSpan, "foo")
+	assert.EqualValues(t, "bar", tag, "getTag unexpected return value")
+
+	sp = tracer.StartSpan("http-client")
+	sp.Finish()
+	rawSpan = sp.(*spanS).raw
+	tag = getTag(rawSpan, "magic")
+	assert.EqualValues(t, "", tag, "getTag should return empty string for non-existent tags")
+}
+
+func TestGetIntTag(t *testing.T) {
+	opts := Options{LogLevel: Debug}
+
+	InitSensor(&opts)
+	recorder := NewTestRecorder()
+	tracer := NewTracerWithEverything(&opts, recorder)
+
+	sp := tracer.StartSpan("http-client")
+	sp.SetTag("one", 1)
+	sp.SetTag("two", "twotwo")
+	sp.Finish()
+	rawSpan := sp.(*spanS).raw
+	tag := getIntTag(rawSpan, "one")
+	assert.EqualValues(t, 1, tag, "geIntTag unexpected return value")
+
+	// Non-existent
+	tag = getIntTag(rawSpan, "thirtythree")
+	assert.EqualValues(t, -1, tag, "geIntTag should return -1 for non-existent tags")
+
+	// Non-Int value (it's a string)
+	tag = getIntTag(rawSpan, "two")
+	assert.EqualValues(t, -1, tag, "geIntTag should return -1 for non-int tags")
+}
+
+func TestGetStringTag(t *testing.T) {
+	opts := Options{LogLevel: Debug}
+
+	InitSensor(&opts)
+	recorder := NewTestRecorder()
+	tracer := NewTracerWithEverything(&opts, recorder)
+
+	sp := tracer.StartSpan("http-client")
+	sp.SetTag("int", 1)
+	sp.SetTag("float", 2.3420493)
+	sp.SetTag("two", "twotwo")
+	sp.Finish()
+	rawSpan := sp.(*spanS).raw
+	tag := getStringTag(rawSpan, "two")
+	assert.EqualValues(t, "twotwo", tag, "geStringTag unexpected return value")
+
+	// Non-existent
+	tag = getStringTag(rawSpan, "thirtythree")
+	assert.EqualValues(t, "", tag, "getStringTag should return empty string for non-existent tags")
+
+	// Non-string value (it's an int)
+	tag = getStringTag(rawSpan, "int")
+	assert.EqualValues(t, "1", tag, "geStringTag should return string for non-string tag values")
+
+	// Non-string value (it's an float)
+	tag = getStringTag(rawSpan, "float")
+	assert.EqualValues(t, "2.3420493", tag, "geStringTag should return string for non-string tag values")
 }

--- a/recorder_internal_test.go
+++ b/recorder_internal_test.go
@@ -180,3 +180,20 @@ func TestGetStringTag(t *testing.T) {
 	tag = getStringTag(rawSpan, "float")
 	assert.EqualValues(t, "2.3420493", tag, "geStringTag should return string for non-string tag values")
 }
+
+func TestGetHostName(t *testing.T) {
+	opts := Options{LogLevel: Debug}
+
+	InitSensor(&opts)
+	recorder := NewTestRecorder()
+	tracer := NewTracerWithEverything(&opts, recorder)
+
+	sp := tracer.StartSpan("http-client")
+	sp.SetTag("int", 1)
+	sp.SetTag("float", 2.3420493)
+	sp.SetTag("two", "twotwo")
+	sp.Finish()
+	rawSpan := sp.(*spanS).raw
+	hostname := getHostName(rawSpan)
+	assert.True(t, len(hostname) > 0, "must return a valid string value")
+}

--- a/recorder_test.go
+++ b/recorder_test.go
@@ -1,0 +1,32 @@
+package instana_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"log"
+	"testing"
+
+	"github.com/instana/golang-sensor"
+	ext "github.com/opentracing/opentracing-go/ext"
+)
+
+func TestRecorderSDKReporting(t *testing.T) {
+	opts := instana.Options{
+		TestMode: true,
+		LogLevel: instana.Debug}
+
+	recorder := instana.NewRecorder(opts.TestMode)
+	tracer := instana.NewTracerWithEverything(&opts, recorder)
+
+	sp := tracer.StartSpan("http-client")
+	sp.SetTag(string(ext.SpanKind), "exit")
+	sp.SetTag("http.status", 200)
+	sp.SetTag("http.url", "https://www.instana.com/product/#technologies")
+	sp.SetTag(string(ext.HTTPMethod), "GET")
+
+	sp.Finish()
+
+	spans := recorder.GetSpans()
+	j, _ := json.MarshalIndent(spans, "", "  ")
+	log.Printf("spans:", bytes.NewBuffer(j))
+}

--- a/recorder_test.go
+++ b/recorder_test.go
@@ -11,17 +11,15 @@ import (
 )
 
 func TestRecorderSDKReporting(t *testing.T) {
-	opts := instana.Options{
-		TestMode: true,
-		LogLevel: instana.Debug}
+	opts := instana.Options{LogLevel: instana.Debug}
 
-	recorder := instana.NewRecorder(opts.TestMode)
+	recorder := instana.NewTestRecorder()
 	tracer := instana.NewTracerWithEverything(&opts, recorder)
 
 	sp := tracer.StartSpan("http-client")
 	sp.SetTag(string(ext.SpanKind), "exit")
 	sp.SetTag("http.status", 200)
-	sp.SetTag("http.url", "https://www.instana.com/product/#technologies")
+	sp.SetTag("http.url", "https://www.instana.com/product/")
 	sp.SetTag(string(ext.HTTPMethod), "GET")
 
 	sp.Finish()

--- a/sdk.go
+++ b/sdk.go
@@ -1,7 +1,9 @@
 package instana
 
 type SDKData struct {
-	Name     string `json:"name"`
-	Type     string `json:"type"`
-	SpanKind string `json:"span.kind"`
+	Name      string      `json:"name"`
+	Type      string      `json:"type"`
+	Arguments string      `json:"arguments"`
+	Return    string      `json:"return"`
+	Custom    *CustomData `json:"custom,omitempty"`
 }

--- a/sdk.go
+++ b/sdk.go
@@ -2,8 +2,8 @@ package instana
 
 type SDKData struct {
 	Name      string      `json:"name"`
-	Type      string      `json:"type"`
-	Arguments string      `json:"arguments"`
-	Return    string      `json:"return"`
+	Type      string      `json:"type,omitempty"`
+	Arguments string      `json:"arguments,omitempty"`
+	Return    string      `json:"return,omitempty"`
 	Custom    *CustomData `json:"custom,omitempty"`
 }

--- a/sdk.go
+++ b/sdk.go
@@ -1,0 +1,7 @@
+package instana
+
+type SDKData struct {
+	Name     string `json:"name"`
+	Type     string `json:"type"`
+	SpanKind string `json:"span.kind"`
+}

--- a/sensor.go
+++ b/sensor.go
@@ -61,9 +61,12 @@ func (r *sensorS) configureServiceName() {
 // InitSensor Intializes the sensor (without tracing) to begin collecting
 // and reporting metrics.
 func InitSensor(options *Options) {
-	sensor = new(sensorS)
-	sensor.initLog()
-	sensor.init(options)
-
-	log.debug("initialized sensor")
+	if sensor == nil {
+		sensor = new(sensorS)
+		sensor.initLog()
+		sensor.init(options)
+		log.debug("initialized sensor")
+	} else {
+		log.debug("not initializing already init'd sensor")
+	}
 }

--- a/tracer.go
+++ b/tracer.go
@@ -102,13 +102,13 @@ func NewTracer() ot.Tracer {
 
 // NewTracerWithOptions Get a new Tracer with the specified options.
 func NewTracerWithOptions(options *Options) ot.Tracer {
-	InitSensor(options)
-
-	return NewTracerWithEverything(options, NewRecorder())
+	return NewTracerWithEverything(options, NewRecorder(options.TestMode))
 }
 
 // NewTracerWithEverything Get a new Tracer with the works.
 func NewTracerWithEverything(options *Options, recorder bt.SpanRecorder) ot.Tracer {
+	InitSensor(options)
+
 	ret := &tracerS{options: bt.Options{
 		Recorder:       recorder,
 		ShouldSample:   shouldSample,

--- a/tracer.go
+++ b/tracer.go
@@ -102,13 +102,14 @@ func NewTracer() ot.Tracer {
 
 // NewTracerWithOptions Get a new Tracer with the specified options.
 func NewTracerWithOptions(options *Options) ot.Tracer {
-	return NewTracerWithEverything(options, NewRecorder(options.TestMode))
+	InitSensor(options)
+
+	return NewTracerWithEverything(options, NewRecorder())
 }
 
 // NewTracerWithEverything Get a new Tracer with the works.
 func NewTracerWithEverything(options *Options, recorder bt.SpanRecorder) ot.Tracer {
 	InitSensor(options)
-
 	ret := &tracerS{options: bt.Options{
 		Recorder:       recorder,
 		ShouldSample:   shouldSample,


### PR DESCRIPTION
Spans are currently reported in generic form.  Using the SDK will allow for better handling, processing and presentation.