### PR TITLE
Better Span Reporting & Minor Cleanup

### DIFF
--- a/recorder.go
+++ b/recorder.go
@@ -166,6 +166,12 @@ func (r *SpanRecorder) reset() {
 }
 
 func (r *SpanRecorder) RecordSpan(rawSpan basictracer.RawSpan) {
+	// If we're not announced and not in test mode then just
+	// return
+	if !r.testMode && !sensor.agent.canSend() {
+		return
+	}
+
 	var data = &Data{}
 	kind := getSpanKind(rawSpan)
 

--- a/recorder.go
+++ b/recorder.go
@@ -145,15 +145,15 @@ func collectLogs(rawSpan basictracer.RawSpan) map[uint64]map[string]interface{} 
 func (r *SpanRecorder) init() {
 	r.reset()
 
-	if r.testMode {
-		log.debug("Recorder in test mode.  Not reporting spans to the backend.")
-	} else {
+	if !r.testMode {
 		ticker := time.NewTicker(1 * time.Second)
 		go func() {
 			for range ticker.C {
-				log.debug("Sending spans to agent", len(r.spans))
-
-				r.send()
+				// Only attempt to send spans if we're announced.
+				if sensor.agent.canSend() {
+					log.debug("Sending spans to agent", len(r.spans))
+					r.send()
+				}
 			}
 		}()
 	}

--- a/sensor.go
+++ b/sensor.go
@@ -66,7 +66,5 @@ func InitSensor(options *Options) {
 		sensor.initLog()
 		sensor.init(options)
 		log.debug("initialized sensor")
-	} else {
-		log.debug("not initializing already init'd sensor")
 	}
 }

--- a/span_test.go
+++ b/span_test.go
@@ -2,12 +2,13 @@ package instana_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/instana/golang-sensor"
 	bt "github.com/opentracing/basictracer-go"
-	//opentracing "github.com/opentracing/opentracing-go"
+	ot "github.com/opentracing/opentracing-go"
 )
 
 func TestBasicSpan(t *testing.T) {
@@ -25,9 +26,44 @@ func TestBasicSpan(t *testing.T) {
 	assert.NotNil(t, span.Context, "Context is nil!")
 	assert.NotNil(t, span.Duration, "Duration is nil!")
 	assert.NotNil(t, span.Operation, "Operation is nil!")
-	assert.NotNil(t, span.ParentSpanID, "ParentSpan is nil!")
+	assert.Equal(t, span.ParentSpanID, uint64(0), "ParentSpan shouldn't have a value")
 	assert.NotNil(t, span.Start, "Start is nil!")
 	assert.Nil(t, span.Tags, "Tags is nil!")
+}
+
+func TestSpanHeritage(t *testing.T) {
+	recorder := bt.NewInMemoryRecorder()
+	tracer := instana.NewTracerWithEverything(&instana.Options{}, recorder)
+
+	parentSpan := tracer.StartSpan("parent")
+
+	childSpan := tracer.StartSpan("child", ot.ChildOf(parentSpan.Context()))
+	time.Sleep(2 * time.Millisecond)
+	childSpan.Finish()
+
+	time.Sleep(2 * time.Millisecond)
+	parentSpan.Finish()
+
+	spans := recorder.GetSpans()
+	assert.Equal(t, len(spans), 2)
+	cSpan := spans[0]
+	pSpan := spans[1]
+
+	assert.Equal(t, "child", cSpan.Operation, "Child span name doesn't compute")
+	assert.Equal(t, "parent", pSpan.Operation, "Parent span name doesn't compute")
+
+	// Parent should not have a parent
+	assert.Equal(t, pSpan.ParentSpanID, uint64(0), "ParentSpanID shouldn't have a value")
+
+	// Child must have parent ID set as parent
+	assert.Equal(t, pSpan.Context.SpanID, cSpan.ParentSpanID, "parentID doesn't match")
+
+	// Must be root span
+	assert.Equal(t, pSpan.Context.TraceID, pSpan.Context.SpanID, "not a root span")
+
+	// Trace ID must be consistent across spans
+	assert.Equal(t, cSpan.Context.TraceID, pSpan.Context.TraceID, "trace IDs don't match")
+
 }
 
 func TestSpanBaggage(t *testing.T) {


### PR DESCRIPTION
We shouldn't queue spans unless we are successfully announced.
Attempt to lower noise in debug logging.