### PR TITLE
Fix rsp body closing on error and empty buffer flush to agent

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -117,10 +117,11 @@ func (r *agentS) fullRequestResponse(url string, method string, data interface{}
 			client := &http.Client{Timeout: 5 * time.Second}
 			resp, err = client.Do(req)
 			if err == nil {
+				defer resp.Body.Close()
+
 				if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 					err = errors.New(resp.Status)
 				} else {
-					defer resp.Body.Close()
 
 					log.debug("agent response:", url, resp.Status)
 


### PR DESCRIPTION
* Fixes closing the response body on error too
* Fixes sending empty requests to the agent every second when the buffer is empty
* Moves the agent/recorder state logic to the senders