### PR TITLE
Error handling inconsistent/not working

### DIFF
--- a/json_span.go
+++ b/json_span.go
@@ -12,6 +12,7 @@ type jsonSpan struct {
 	Duration  uint64    `json:"d"`
 	Name      string    `json:"n"`
 	From      *fromS    `json:"f"`
+	Ec        int       `json:"ec,omitempty"`
 	Data      *jsonData `json:"data"`
 }
 

--- a/json_span.go
+++ b/json_span.go
@@ -13,6 +13,7 @@ type jsonSpan struct {
 	Name      string    `json:"n"`
 	From      *fromS    `json:"f"`
 	Ec        int       `json:"ec,omitempty"`
+	Lang      string    `json:"ta,omitempty"`
 	Data      *jsonData `json:"data"`
 }
 

--- a/recorder.go
+++ b/recorder.go
@@ -121,6 +121,7 @@ func (r *Recorder) RecordSpan(span *spanS) {
 		Timestamp: uint64(span.Start.UnixNano()) / uint64(time.Millisecond),
 		Duration:  uint64(span.Duration) / uint64(time.Millisecond),
 		Name:      "sdk",
+		Ec:        span.Ec,
 		From:      sensor.agent.from,
 		Data:      data})
 

--- a/recorder.go
+++ b/recorder.go
@@ -122,6 +122,7 @@ func (r *Recorder) RecordSpan(span *spanS) {
 		Duration:  uint64(span.Duration) / uint64(time.Millisecond),
 		Name:      "sdk",
 		Ec:        span.Ec,
+		Lang:      "go",
 		From:      sensor.agent.from,
 		Data:      data})
 

--- a/span.go
+++ b/span.go
@@ -22,6 +22,7 @@ type spanS struct {
 	Duration     time.Duration
 	Tags         ot.Tags
 	Logs         []ot.LogRecord
+	Ec           int
 }
 
 func (r *spanS) BaggageItem(key string) string {
@@ -109,6 +110,14 @@ func (r *spanS) LogEventWithPayload(event string, payload interface{}) {
 }
 
 func (r *spanS) LogFields(fields ...otlog.Field) {
+
+	for _, v := range fields {
+		// If this tag indicates an error, increase the error count
+		if v.Key() == "error" {
+			r.Ec++
+		}
+	}
+
 	lr := ot.LogRecord{
 		Fields: fields,
 	}
@@ -154,6 +163,11 @@ func (r *spanS) SetTag(key string, value interface{}) ot.Span {
 
 	if r.Tags == nil {
 		r.Tags = ot.Tags{}
+	}
+
+	// If this tag indicates an error, increase the error count
+	if key == "error" {
+		r.Ec++
 	}
 
 	r.Tags[key] = value

--- a/span_test.go
+++ b/span_test.go
@@ -35,6 +35,7 @@ func TestBasicSpan(t *testing.T) {
 	assert.Equal(t, "test", span.Data.SDK.Name, "Missing span name")
 	assert.Nil(t, span.Data.SDK.Custom.Tags, "Tags has an unexpected value")
 	assert.Nil(t, span.Data.SDK.Custom.Baggage, "Baggage has an unexpected value")
+	assert.Equal(t, "go", span.Lang, "Missing or wrong ta/lang")
 }
 
 func TestSpanHeritage(t *testing.T) {


### PR DESCRIPTION
@boyand  reports that logged errors aren't properly displayed and the span isn't mark as errored.

> it seems OT errors are not handled currently
> the error data we send is not displayed in “data”
> and the span is also not shown as error

- [x] Review/fix error handling/reporting
- [x] Add tests to validate