### PR TITLE
Error on parsing X-Instana-S and X-Instana-T

### DIFF
--- a/util.go
+++ b/util.go
@@ -1,6 +1,9 @@
 package instana
 
 import (
+	"bytes"
+	"encoding/binary"
+	"errors"
 	"io/ioutil"
 	"math/rand"
 	"os"
@@ -19,6 +22,55 @@ func randomID() int64 {
 	seededIDLock.Lock()
 	defer seededIDLock.Unlock()
 	return int64(seededIDGen.Int63())
+}
+
+// ID2Header converts an Instana ID to a value that can be used in
+// context propagation (such as HTTP headers).  More specifically,
+// this converts a signed 64 bit integer into an unsigned hex string.
+func ID2Header(id int64) (string, error) {
+	// FIXME: We're assuming LittleEndian here
+
+	// Write out _signed_ 64bit integer to byte buffer
+	buf := new(bytes.Buffer)
+	if err := binary.Write(buf, binary.LittleEndian, id); err == nil {
+		// Read bytes back into _unsigned_ 64 bit integer
+		var unsigned uint64
+		if err = binary.Read(buf, binary.LittleEndian, &unsigned); err == nil {
+			// Convert uint64 to hex string equivalent and return that
+			return strconv.FormatUint(unsigned, 16), nil
+		}
+		log.debug(err)
+	} else {
+		log.debug(err)
+	}
+	return "", errors.New("Context corrupted; could not convert value.")
+}
+
+// Header2ID converts an header context value into an Instana ID.  More
+// specifically, this converts an unsigned 64 bit hex value into a signed
+// 64bit integer.
+func Header2ID(header string) (int64, error) {
+	// FIXME: We're assuming LittleEndian here
+
+	// Parse unsigned 64 bit hex string into unsigned 64 bit base 10 integer
+	if unsignedID, err := strconv.ParseUint(header, 16, 64); err == nil {
+		// Write out _unsigned_ 64bit integer to byte buffer
+		buf := new(bytes.Buffer)
+		if err = binary.Write(buf, binary.LittleEndian, unsignedID); err == nil {
+			// Read bytes back into _signed_ 64 bit integer
+			var signedID int64
+			if err = binary.Read(buf, binary.LittleEndian, &signedID); err == nil {
+				// The success case
+				return signedID, nil
+			}
+			log.debug(err)
+		} else {
+			log.debug(err)
+		}
+	} else {
+		log.debug(err)
+	}
+	return int64(0), errors.New("Context corrupted; could not convert value.")
 }
 
 func getCommandLine() (string, []string) {

--- a/util.go
+++ b/util.go
@@ -43,7 +43,7 @@ func ID2Header(id int64) (string, error) {
 	} else {
 		log.debug(err)
 	}
-	return "", errors.New("Context corrupted; could not convert value.")
+	return "", errors.New("context corrupted; could not convert value")
 }
 
 // Header2ID converts an header context value into an Instana ID.  More
@@ -70,7 +70,7 @@ func Header2ID(header string) (int64, error) {
 	} else {
 		log.debug(err)
 	}
-	return int64(0), errors.New("Context corrupted; could not convert value.")
+	return int64(0), errors.New("context corrupted; could not convert value")
 }
 
 func getCommandLine() (string, []string) {

--- a/util_internal_test.go
+++ b/util_internal_test.go
@@ -13,14 +13,42 @@ const MinInt64 = int64(-9223372036854775808)
 const MaxInt64 = int64(9223372036854775807)
 
 func TestGeneratedIDRange(t *testing.T) {
-
 	var count = 10000
-	var id = int64(0)
 	for index := 0; index < count; index++ {
-		id = randomID()
-
+		id := randomID()
 		assert.True(t, id <= 9223372036854775807, "Generated ID is out of bounds (+)")
 		assert.True(t, id >= -9223372036854775808, "Generated ID is out of bounds (-)")
-
 	}
+}
+
+func TestIDConversionBackForth(t *testing.T) {
+	maxID := int64(9223372036854775807)
+	minID := int64(-9223372036854775808)
+	maxHex := "7fffffffffffffff"
+	minHex := "8000000000000000"
+
+	// Place holders
+	var header string
+	var id int64
+
+	// maxID (int64) -> header -> int64
+	header, _ = ID2Header(maxID)
+	id, _ = Header2ID(header)
+	assert.Equal(t, maxHex, header, "ID2Header incorrect result.")
+	assert.Equal(t, maxID, id, "Convert back into original is wrong")
+
+	// minHex (unsigned 64bit hex string) -> signed 64bit int -> unsigned 64bit hex string
+	id, _ = Header2ID(minHex)
+	header, _ = ID2Header(id)
+	assert.Equal(t, minID, id, "Header2ID incorrect result")
+	assert.Equal(t, minHex, header, "Convert back into original is wrong")
+}
+
+func TestBogusValues(t *testing.T) {
+	var id int64
+
+	// Header2ID with random strings should return 0
+	id, err := Header2ID("this shouldnt work")
+	assert.Equal(t, int64(0), id, "Bad input should return 0")
+	assert.NotNil(t, err, "An error should be returned")
 }

--- a/util_internal_test.go
+++ b/util_internal_test.go
@@ -44,6 +44,36 @@ func TestIDConversionBackForth(t *testing.T) {
 	assert.Equal(t, minHex, header, "Convert back into original is wrong")
 }
 
+func TestIDConversion(t *testing.T) {
+	// Place holders
+	var header string
+	var id int64
+
+	header, _ = ID2Header(-7815363404733516491)
+	assert.Equal(t, "938a406416457535", header, "ID2Header incorrect result.")
+	id, _ = Header2ID("938a406416457535")
+	assert.Equal(t, int64(-7815363404733516491), id, "Header2ID incorrect result")
+
+	header, _ = ID2Header(307170163380978816)
+	assert.Equal(t, "44349a2d9ec0480", header, "ID2Header incorrect result.")
+	id, _ = Header2ID("44349a2d9ec0480") // Without a leading zero
+	assert.Equal(t, int64(307170163380978816), id, "Header2ID incorrect result")
+	id, _ = Header2ID("044349a2d9ec0480") // Try with a leading zero
+	assert.Equal(t, int64(307170163380978816), id, "Header2ID incorrect result")
+
+	header, _ = ID2Header(2920004540187184976)
+	assert.Equal(t, "2885f0a890628f50", header, "ID2Header incorrect result.")
+	id, _ = Header2ID("2885f0a890628f50")
+	assert.Equal(t, int64(2920004540187184976), id, "Header2ID incorrect result")
+
+	header, _ = ID2Header(16)
+	assert.Equal(t, "10", header, "ID2Header should drop leading zeros")
+	id, _ = Header2ID("0000000000000010")
+	assert.Equal(t, int64(16), id, "Header2ID should stll work with leading zeros")
+	id, _ = Header2ID("10")
+	assert.Equal(t, int64(16), id, "Header2ID should convert <16 char strings")
+}
+
 func TestBogusValues(t *testing.T) {
 	var id int64
 

--- a/util_internal_test.go
+++ b/util_internal_test.go
@@ -72,6 +72,14 @@ func TestIDConversion(t *testing.T) {
 	assert.Equal(t, int64(16), id, "Header2ID should stll work with leading zeros")
 	id, _ = Header2ID("10")
 	assert.Equal(t, int64(16), id, "Header2ID should convert <16 char strings")
+
+	count := 10000
+	for index := 0; index < count; index++ {
+		generatedID := randomID()
+		header, _ := ID2Header(generatedID)
+		id, _ := Header2ID(header)
+		assert.Equal(t, generatedID, id, "Original ID does not match converted back ID")
+	}
 }
 
 func TestBogusValues(t *testing.T) {


### PR DESCRIPTION
X-Instana-S and X-Instana-T headers may contain values between 0 and math.MaxUint64, but textMapPropagator.extract() uses strconv.ParseInt() to parse these headers instead of strconv.ParseUint().

This error cannot be observed if a golang service receives a request from another golang service, because instana/golang-sensor just generates IDs between 0 and math.MaxInt64 by using Rand.Int63(), so these IDs will be parsed well.