### PR TITLE
Delete pre-existing HTTP Header keys to avoid append

### DIFF
--- a/recorder.go
+++ b/recorder.go
@@ -68,7 +68,14 @@ func (r *Recorder) init() {
 func (r *Recorder) Reset() {
 	r.Lock()
 	defer r.Unlock()
-	r.spans = make([]jsonSpan, 0, sensor.options.MaxBufferedSpans)
+
+	var mbs int
+	if sensor != nil {
+		mbs = sensor.options.MaxBufferedSpans
+	} else {
+		mbs = DefaultMaxBufferedSpans
+	}
+	r.spans = make([]jsonSpan, 0, mbs)
 }
 
 // RecordSpan accepts spans to be recorded and sent to the backend

--- a/sensor.go
+++ b/sensor.go
@@ -6,8 +6,8 @@ import (
 )
 
 const (
-	defaultMaxBufferedSpans = 1000
-	defaultForceSpanSendAt  = 500
+	DefaultMaxBufferedSpans = 1000
+	DefaultForceSpanSendAt  = 500
 )
 
 type sensorS struct {
@@ -36,11 +36,11 @@ func (r *sensorS) setOptions(options *Options) {
 	}
 
 	if r.options.MaxBufferedSpans == 0 {
-		r.options.MaxBufferedSpans = defaultMaxBufferedSpans
+		r.options.MaxBufferedSpans = DefaultMaxBufferedSpans
 	}
 
 	if r.options.ForceTransmissionStartingAt == 0 {
-		r.options.ForceTransmissionStartingAt = defaultForceSpanSendAt
+		r.options.ForceTransmissionStartingAt = DefaultForceSpanSendAt
 	}
 }
 


### PR DESCRIPTION
If you re-use the `net/http` request object and pass `request.Header` to the `tracer.Inject` function multiple times, values will actually get appended to already set headers.

This is because the `TextMapWriter` [interface](https://github.com/opentracing/opentracing-go/blob/master/propagation.go#L95-L104) in Go OpenTracing calls only `http.Header.Add()` (as [seen here](https://github.com/opentracing/opentracing-go/blob/master/propagation.go#L162-L163)) and the end implementation of `Add()` in `http.Header` states [It appends to any existing values associated with key](https://golang.org/src/net/http/header.go).

This PR checks for and deletes any pre-existing keys on `Inject`.

Thanks @vetinari for the heads up and a test to demonstrate.