### PR TITLE
Only report custom service name from tracer (if configured)

### DIFF
--- a/recorder.go
+++ b/recorder.go
@@ -107,7 +107,7 @@ func (r *Recorder) RecordSpan(span *spanS) {
 		data.SDK.Custom.Baggage = baggage
 	}
 
-	data.Service = span.getServiceName()
+	data.Service = sensor.serviceName
 
 	var parentID *int64
 	if span.ParentSpanID == 0 {

--- a/recorder_internal_test.go
+++ b/recorder_internal_test.go
@@ -7,64 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetServiceNameByTracer(t *testing.T) {
-	opts := Options{LogLevel: Debug, Service: "tracer-named-service"}
-
-	// nilify any previously instantiated sensor
-	sensor = nil
-	InitSensor(&opts)
-	recorder := NewTestRecorder()
-	tracer := NewTracerWithEverything(&opts, recorder)
-
-	sp := tracer.StartSpan("http-client")
-	sp.SetTag(string(ext.SpanKind), "exit")
-	sp.SetTag("http.status", 200)
-	sp.SetTag(string(ext.HTTPMethod), "GET")
-
-	sp.Finish()
-
-	serviceName := sp.(*spanS).getServiceName()
-	assert.EqualValues(t, "tracer-named-service", serviceName, "Wrong Service Name")
-}
-
-func TestGetServiceNameByHTTP(t *testing.T) {
-	opts := Options{LogLevel: Debug}
-
-	InitSensor(&opts)
-	recorder := NewTestRecorder()
-	tracer := NewTracerWithEverything(&opts, recorder)
-
-	span := tracer.StartSpan("http-client")
-	span.SetTag(string(ext.SpanKind), "exit")
-	span.SetTag("http.status", 200)
-	span.SetTag("http.url", "https://www.instana.com/product/")
-	span.SetTag(string(ext.HTTPMethod), "GET")
-
-	span.Finish()
-
-	serviceName := span.(*spanS).getServiceName()
-	assert.EqualValues(t, "https://www.instana.com/product/", serviceName, "Wrong Service Name")
-}
-
-func TestGetServiceNameByComponent(t *testing.T) {
-	opts := Options{LogLevel: Debug}
-
-	InitSensor(&opts)
-	recorder := NewTestRecorder()
-	tracer := NewTracerWithEverything(&opts, recorder)
-
-	span := tracer.StartSpan("http-client")
-	span.SetTag(string(ext.SpanKind), "exit")
-	span.SetTag("http.status", 200)
-	span.SetTag("component", "component-named-service")
-	span.SetTag(string(ext.HTTPMethod), "GET")
-
-	span.Finish()
-
-	serviceName := span.(*spanS).getServiceName()
-	assert.EqualValues(t, "component-named-service", serviceName, "Wrong Service Name")
-}
-
 func TestSpanKind(t *testing.T) {
 	opts := Options{LogLevel: Debug}
 

--- a/span.go
+++ b/span.go
@@ -225,24 +225,6 @@ func (r *spanS) getHostName() string {
 	return h
 }
 
-func (r *spanS) getServiceName() string {
-	// ServiceName can be determined from multiple sources and has
-	// the following priority (preferred first):
-	//   1. If added to the span via the OT component tag
-	//   2. If added to the span via the OT http.url tag
-	//   3. Specified in the tracer instantiation via Service option
-	component := r.getStringTag(string(ext.Component))
-	if len(component) > 0 {
-		return component
-	}
-
-	httpURL := r.getStringTag(string(ext.HTTPUrl))
-	if len(httpURL) > 0 {
-		return httpURL
-	}
-	return sensor.serviceName
-}
-
 func (r *spanS) getSpanKind() string {
 	kind := r.getStringTag(string(ext.SpanKind))
 


### PR DESCRIPTION
This PR fixes custom service naming in the Instana dashboard.