### PR TITLE
Improved Recorder: better queue locking & management

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -141,7 +141,12 @@ func (r *agentS) fullRequestResponse(url string, method string, data interface{}
 	}
 
 	if err != nil {
-		log.info(err, url)
+		// Ignore errors while in announced stated (before ready) as
+		// this is the time where the entity is registering in the Instana
+		// backend and it will return 404 until it's done.
+		if !r.sensor.agent.fsm.fsm.Is("announced") {
+			log.info(err, url)
+		}
 	}
 
 	return ret, err

--- a/example/webserver/http.go
+++ b/example/webserver/http.go
@@ -62,6 +62,8 @@ func server() {
 
 		time.Sleep(550 * time.Millisecond)
 
+		ot.GlobalTracer().Inject(parentSpan.Context(), ot.HTTPHeaders, ot.HTTPHeadersCarrier(w.Header()))
+
 		parentSpan.Finish()
 	})
 
@@ -75,7 +77,7 @@ func server() {
 func main() {
 	ot.InitGlobalTracer(instana.NewTracerWithOptions(&instana.Options{
 		Service:  Service,
-		LogLevel: instana.Debug}))
+		LogLevel: instana.Info}))
 
 	go server()
 

--- a/propagation_test.go
+++ b/propagation_test.go
@@ -46,7 +46,7 @@ func TestSpanPropagator(t *testing.T) {
 
 	sp.Finish()
 
-	spans := recorder.GetSpans()
+	spans := recorder.GetQueuedSpans()
 	if a, e := len(spans), len(tests)+1; a != e {
 		t.Fatalf("expected %d spans, got %d", e, a)
 	}
@@ -125,7 +125,7 @@ func TestCaseSensitiveHeaderPropagation(t *testing.T) {
 
 	}
 
-	for _, s := range recorder.GetSpans() {
+	for _, s := range recorder.GetQueuedSpans() {
 		assert.Equal(t, spanParentIDBase64, *s.ParentID)
 		assert.NotEqual(t, spanParentIDBase64, s.SpanID)
 	}
@@ -175,12 +175,12 @@ func TestSingleHeaderPropagation(t *testing.T) {
 		}
 
 		child.Finish()
-		s := recorder.GetSpans()[0]
+		s := recorder.GetQueuedSpans()[0]
 		assert.Equal(t, child.BaggageItem("foo"), "baz")
 		assert.Equal(t, []string{fmt.Sprintf("%x", s.SpanID)}, http.Header(test.carrier.(opentracing.HTTPHeadersCarrier))["X-Instana-S"])
 	}
 
-	for _, s := range recorder.GetSpans() {
+	for _, s := range recorder.GetQueuedSpans() {
 		assert.Equal(t, spanParentIDBase64, *s.ParentID)
 		assert.NotEqual(t, spanParentIDBase64, s.SpanID)
 	}

--- a/recorder.go
+++ b/recorder.go
@@ -120,6 +120,14 @@ func (r *Recorder) RecordSpan(span *spanS) {
 	}
 }
 
+// QueuedSpansCount returns the number of queued spans
+//   Used only in tests currently.
+func (r *Recorder) QueuedSpansCount() int {
+	r.RLock()
+	defer r.RUnlock()
+	return len(r.spans)
+}
+
 // GetQueuedSpans returns a copy of the queued spans and clears the queue.
 func (r *Recorder) GetQueuedSpans() []jsonSpan {
 	r.Lock()

--- a/recorder_test.go
+++ b/recorder_test.go
@@ -20,12 +20,8 @@ func TestRecorderBasics(t *testing.T) {
 	span.SetTag(string(ext.HTTPMethod), "GET")
 	span.Finish()
 
-	// Validate GetSpans
-	spans := recorder.GetSpans()
+	// Validate GetQueuedSpans returns queued spans and clears the queue
+	spans := recorder.GetQueuedSpans()
 	assert.Equal(t, 1, len(spans))
-
-	// Validate Reset & GetSpans Result
-	recorder.Reset()
-	spans = recorder.GetSpans()
-	assert.Equal(t, 0, len(spans))
+	assert.Equal(t, 0, recorder.QueuedSpansCount())
 }

--- a/span_test.go
+++ b/span_test.go
@@ -23,7 +23,7 @@ func TestBasicSpan(t *testing.T) {
 	sp := tracer.StartSpan(op)
 	sp.Finish()
 
-	spans := recorder.GetSpans()
+	spans := recorder.GetQueuedSpans()
 	assert.Equal(t, 1, len(spans))
 	span := spans[0]
 
@@ -51,7 +51,7 @@ func TestSpanHeritage(t *testing.T) {
 	time.Sleep(2 * time.Millisecond)
 	parentSpan.Finish()
 
-	spans := recorder.GetSpans()
+	spans := recorder.GetQueuedSpans()
 	assert.Equal(t, len(spans), 2)
 	cSpan := spans[0]
 	pSpan := spans[1]
@@ -83,7 +83,7 @@ func TestSpanBaggage(t *testing.T) {
 	sp.SetBaggageItem("foo", "bar")
 	sp.Finish()
 
-	spans := recorder.GetSpans()
+	spans := recorder.GetQueuedSpans()
 	assert.Equal(t, len(spans), 1)
 	span := spans[0]
 
@@ -100,7 +100,7 @@ func TestSpanTags(t *testing.T) {
 	sp.SetTag("foo", "bar")
 	sp.Finish()
 
-	spans := recorder.GetSpans()
+	spans := recorder.GetQueuedSpans()
 	assert.Equal(t, len(spans), 1)
 	span := spans[0]
 
@@ -120,7 +120,7 @@ func TestSpanLogFields(t *testing.T) {
 		log.Int("waited.millis", 1500))
 	span.Finish()
 
-	spans := recorder.GetSpans()
+	spans := recorder.GetQueuedSpans()
 	assert.Equal(t, len(spans), 1)
 	firstSpan := spans[0]
 
@@ -151,7 +151,7 @@ func TestSpanLogKVs(t *testing.T) {
 		"waited.millis", 1500)
 	span.Finish()
 
-	spans := recorder.GetSpans()
+	spans := recorder.GetQueuedSpans()
 	assert.Equal(t, len(spans), 1)
 	firstSpan := spans[0]
 
@@ -179,7 +179,7 @@ func TestOTLogError(t *testing.T) {
 	ext.Error.Set(span, true)
 	span.Finish()
 
-	spans := recorder.GetSpans()
+	spans := recorder.GetQueuedSpans()
 	assert.Equal(t, len(spans), 1)
 	firstSpan := spans[0]
 
@@ -208,7 +208,7 @@ func TestSpanErrorLogKV(t *testing.T) {
 	span.LogKV("error", "simulated error")
 	span.Finish()
 
-	spans := recorder.GetSpans()
+	spans := recorder.GetQueuedSpans()
 	assert.Equal(t, len(spans), 1)
 	firstSpan := spans[0]
 
@@ -240,7 +240,7 @@ func TestSpanErrorLogFields(t *testing.T) {
 	span.LogFields(log.Error(err), log.String("function", "TestspanErrorLogFields"))
 	span.Finish()
 
-	spans := recorder.GetSpans()
+	spans := recorder.GetQueuedSpans()
 	assert.Equal(t, len(spans), 1)
 	firstSpan := spans[0]
 

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -31,7 +31,6 @@ func TestTracerBasics(t *testing.T) {
 	sp.SetBaggageItem("foo", "bar")
 	sp.Finish()
 
-	spans := recorder.GetSpans()
+	spans := recorder.GetQueuedSpans()
 	assert.Equal(t, len(spans), 1)
-	recorder.Reset()
 }


### PR DESCRIPTION
This PR improves the Recorder:

- Rename some functions to better reflect their use
- Centralize/limit locking locations
- Simplify queued span retrieval and clearing of the queue
- Update tests to follow changes