### PR TITLE
Possible Deadlock in Recorder

### DIFF
--- a/recorder.go
+++ b/recorder.go
@@ -116,7 +116,7 @@ func (r *Recorder) RecordSpan(span *spanS) {
 
 	if len(r.spans) >= sensor.options.ForceTransmissionStartingAt {
 		log.debug("Forcing spans to agent.  Count:", len(r.spans))
-		r.send()
+		go r.send()
 	}
 }
 


### PR DESCRIPTION
Hi,

We're using this version of the golang-sensor, which is basically up-to-date:
```
{
        "checksumSHA1": "tT7TxSWCe35FOPW9lanBa4VXrWM=",
        "path": "github.com/instana/golang-sensor",
        "revision": "73da7cd97173f42577e1a475f44ffe6ad2601502",
        "revisionTime": "2017-10-11T08:20:13Z"
}
```

While doing some load testing with our services I've found that we seem to be running into some weird behavior where the number of goroutines skyrockets and even after we remove the load the number of goroutines stays high and never goes back down unless I restart the service. In addition to the high numbers, the service seems to become basically unresponsive.

After doing some profiling I found this:

```
goroutine profile: total 1626
1595 @ 0x42db2c 0x42dc1e 0x43f154 0x43ee6d 0x472bce 0x473bcd 0x944a6c 0x94610a 0x945af6 0x94c2b5 0x957300 0x990532 0x9932c7 0x98bfeb 0x45a84b 0x4b6575 0x4b5b54 0x771cf5 0x94f261 0x9013b7 0x9514fa 0x76d1c3 0x76d842 0x767813 0x773a1e 0x75cb32 0x45cfc1
#	0x43ee6c	sync.runtime_SemacquireMutex+0x3c																								/usr/local/go/src/runtime/sema.go:71
#	0x472bcd	sync.(*Mutex).Lock+0xed																										/usr/local/go/src/sync/mutex.go:134
#	0x473bcc	sync.(*RWMutex).Lock+0x2c																									/usr/local/go/src/sync/rwmutex.go:93
#	0x944a6b	bitbucket.org/mycompany/sessionservice/vendor/github.com/instana/golang-sensor.(*Recorder).RecordSpan+0x2ab													/go/src/bitbucket.org/mycompany/sessionservice/vendor/github.com/instana/golang-sensor/recorder.go:93
#	0x946109	bitbucket.org/mycompany/sessionservice/vendor/github.com/instana/golang-sensor.(*spanS).FinishWithOptions+0x5f9												/go/src/bitbucket.org/mycompany/sessionservice/vendor/github.com/instana/golang-sensor/span.go:74
#	0x945af5	bitbucket.org/mycompany/sessionservice/vendor/github.com/instana/golang-sensor.(*spanS).Finish+0x55														/go/src/bitbucket.org/mycompany/sessionservice/vendor/github.com/instana/golang-sensor/span.go:53
#	0x94c2b4	bitbucket.org/mycompany/sessionservice/vendor/bitbucket.org/company/com%2ecompany%2elib%2etracing-go.WrapCustomCall+0x254											/go/src/bitbucket.org/mycompany/sessionservice/vendor/bitbucket.org/company/com.company.lib.tracing-go/custom.go:37
#	0x9572ff	bitbucket.org/mycompany/sessionservice/auth.(*AuthService).Login+0x1df																		/go/src/bitbucket.org/mycompany/sessionservice/auth/service.go:113
#	0x990531	bitbucket.org/mycompany/sessionservice/sessionmanager.(*Manager).Login+0xc1																	/go/src/bitbucket.org/mycompany/sessionservice/sessionmanager/manager.go:58
#	0x9932c6	bitbucket.org/mycompany/sessionservice/handler.(*UserSession).Login+0x176																	/go/src/bitbucket.org/mycompany/sessionservice/handler/usersession.go:25
#	0x98bfea	bitbucket.org/mycompany/sessionservice/proto/src/go.(*UserSession).Login+0x5a																	/go/src/bitbucket.org/mycompany/sessionservice/proto/src/go/usersession.pb.go:402
#	0x45a84a	runtime.call64+0x3a																										/usr/local/go/src/runtime/asm_amd64.s:510
#	0x4b6574	reflect.Value.call+0x904																									/usr/local/go/src/reflect/value.go:434
#	0x4b5b53	reflect.Value.Call+0xa3																										/usr/local/go/src/reflect/value.go:302
#	0x771cf4	bitbucket.org/mycompany/sessionservice/vendor/github.com/micro/go-micro/server.(*service).call.func1+0x204													/go/src/bitbucket.org/mycompany/sessionservice/vendor/github.com/micro/go-micro/server/rpc_service.go:232
#	0x94f260	bitbucket.org/mycompany/sessionservice/vendor/bitbucket.org/company/com%2ecompany%2elib%2etracing-go.HandlerWrapper.func1+0x310										/go/src/bitbucket.org/mycompany/sessionservice/vendor/bitbucket.org/company/com.company.lib.tracing-go/micro.go:113
#	0x9013b6	bitbucket.org/mycompany/sessionservice/vendor/bitbucket.org/company/com%2ecompany%2elib%2emetrics-go.HandlerWrapper.func1+0x296										/go/src/bitbucket.org/mycompany/sessionservice/vendor/bitbucket.org/company/com.company.lib.metrics-go/micro.go:113
#	0x9514f9	bitbucket.org/mycompany/sessionservice/vendor/bitbucket.org/company/com%2ecompany%2elib%2etelemetry-go.correlationIdWrapper.func1+0x89									/go/src/bitbucket.org/mycompany/sessionservice/vendor/bitbucket.org/company/com.company.lib.telemetry-go/wrappers.go:13
#	0x76d1c2	bitbucket.org/mycompany/sessionservice/vendor/github.com/micro/go-micro/server.(*service).call+0x722														/go/src/bitbucket.org/mycompany/sessionservice/vendor/github.com/micro/go-micro/server/rpc_service.go:247
#	0x76d841	bitbucket.org/mycompany/sessionservice/vendor/github.com/micro/go-micro/server.(*server).serveRequest+0x271													/go/src/bitbucket.org/mycompany/sessionservice/vendor/github.com/micro/go-micro/server/rpc_service.go:327
#	0x767812	bitbucket.org/mycompany/sessionservice/vendor/github.com/micro/go-micro/server.(*rpcServer).accept+0x282													/go/src/bitbucket.org/mycompany/sessionservice/vendor/github.com/micro/go-micro/server/rpc_server.go:111
#	0x773a1d	bitbucket.org/mycompany/sessionservice/vendor/github.com/micro/go-micro/server.(*rpcServer).(bitbucket.org/mycompany/sessionservice/vendor/github.com/micro/go-micro/server.accept)-fm+0x3d	/go/src/bitbucket.org/mycompany/sessionservice/vendor/github.com/micro/go-micro/server/rpc_server.go:393
#	0x75cb31	bitbucket.org/mycompany/sessionservice/vendor/github.com/micro/go-micro/transport.(*httpTransportListener).Accept.func1+0x61											/go/src/bitbucket.org/mycompany/sessionservice/vendor/github.com/micro/go-micro/transport/http_transport.go:327
```

Could it be that it's somehow getting stuck on recorder.go line 93 while it tries to acquire a mutex lock?

Regards,
Scott